### PR TITLE
7 add small variant list module

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -37,4 +37,12 @@ process {
         ]
     }
 
+    withName: UPDATE_SMALL_VARIANT_VCF_LIST {
+        publishDir = [
+            path: { "${params.outdir}/pipeline_info" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
 }

--- a/conf/test_stub.config
+++ b/conf/test_stub.config
@@ -26,4 +26,5 @@ params {
     input                  = 'assets/example.samplesheet.csv'
     outdir                 = 'test_stub'
     tso500_resource_folder = 'assets/example.tso500_resource_folder'
+    small_variant_vcf_list = 'assets/TSO500_vcf_list.tsv'
 }

--- a/modules/local/update_small_variant_vcf_list/update_small_variant_vcf_list.nf
+++ b/modules/local/update_small_variant_vcf_list/update_small_variant_vcf_list.nf
@@ -1,0 +1,114 @@
+process UPDATE_SMALL_VARIANT_VCF_LIST {
+    tag "$id"
+    label 'process_low'
+
+    container 'ubuntu:24.04'
+
+    input:
+    tuple val(id), path(results)
+    path vcf_list
+
+    output:
+    tuple val(id), path("TSO500_vcf_list.tsv") , emit: tsv
+    path "versions.yml"                        , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def controlPrefix = "IPC"
+    def tmp_list = "TSO500_vcf_list.tsv.tmp"
+    """
+    echo "[INFO] generating updated temporary VCF list with VCF files from run ${id}"
+    cat ${vcf_list} <(ls -1 ${results}/*/*/*_MergedSmallVariants.genome.vcf \\
+        | sed "s/\\(.*\\/\\)\\(.*\\)\\(_MergedSmallVariants.genome.vcf\\)/\\\\1\\\\2\\\\3	\\\\2/" \\
+        | awk 'OFS="\t" {print \$1, substr(\$2, 13, 1)}') \\
+        > ${tmp_list}
+
+    BAD_SAMPLE_TYPE_CODES=()
+    for SAMPLE_VCF in `ls -1 ${results}/*/*/*_MergedSmallVariants.genome.vcf`
+    do
+      SAMPLE_ID=`echo \${SAMPLE_VCF} | sed "s/\\(.*\\/\\)\\(.*\\)\\(_MergedSmallVariants.genome.vcf\\)/\\\\2/"`
+      SAMPLE_TYPE_CODE=`echo \${SAMPLE_ID} | awk '{print substr(\$1, 13, 1)}'`
+
+      # check that sample type code is not an empty string
+      if [[  -z "\${SAMPLE_TYPE_CODE// }" ]]
+      then
+          echo "[ERR] \\\$SAMPLE_TYPE_CODE cannot be empty! Check that sample IDs follow inpred nomenclature"
+          echo "[ERR] Exiting now..."
+          exit 1
+      fi
+
+      PATIENT_ID=\${SAMPLE_ID%%-*}
+      PATIENT_SAMPLE_COUNT=`grep "\${PATIENT_ID}" ${tmp_list} | wc -l`
+
+      SAMPLE_TYPE_CODE_OK_STRING="[OK]"
+      if [ \${SAMPLE_TYPE_CODE} != "T" ] && [ \${SAMPLE_TYPE_CODE} != "N" ]
+      then
+        SAMPLE_TYPE_CODE_OK_STRING="[not \"T\" or \"N\"!]"
+        echo "[WARN] Unknown sample type code '\$SAMPLE_TYPE_CODE' encountered!"
+        echo "[WARN] Only sample type codes 'T' and 'N' are allowed in the VCF list file!"
+        case \${SAMPLE_TYPE_CODE} in
+            ["P","p","R","r","D","d","C","L","M","X"])
+            echo "[INFO] Replacing sample type code '\$SAMPLE_TYPE_CODE' with value 'T' "
+            sed -i 's/[P,p,R,r,D,d,C,L,M,X]\$/T/' ${tmp_list}
+            SAMPLE_TYPE_CODE="T"
+            SAMPLE_TYPE_CODE_OK_STRING="[OK]"
+            ;;
+        *)
+            echo "[WARN] You need to manually edit ${tmp_list} by replacing the unknown sample type code '\$SAMPLE_TYPE_CODE' with either 'T' or 'N' "
+            BAD_SAMPLE_TYPE_CODES+=(\${SAMPLE_TYPE_CODE})
+            ;;
+        esac
+      fi
+
+      PATIENT_SAMPLE_COUNT_OK_STRING="[OK]"
+      if [ \${PATIENT_SAMPLE_COUNT} -ne 1 ]
+      then
+        PATIENT_SAMPLE_COUNT_OK_STRING="[not 1!]"
+      fi
+
+      echo "[INFO] sample VCF: \${SAMPLE_VCF}"
+      echo "[INFO] sample ID: \${SAMPLE_ID}"
+      echo "[INFO] sample type code: \${SAMPLE_TYPE_CODE} \${SAMPLE_TYPE_CODE_OK_STRING}"
+      echo "[INFO] patient ID: \${PATIENT_ID}"
+      echo "[INFO] patient sample count: \${PATIENT_SAMPLE_COUNT} \${PATIENT_SAMPLE_COUNT_OK_STRING}"
+    done
+
+    if [ \${#BAD_SAMPLE_TYPE_CODES[@]} -gt 0 ]
+    then
+      echo "[ERR] The following unknown SAMPLE_TYPE_CODE(s) exist in ${tmp_list}:"
+      echo "\${BAD_SAMPLE_TYPE_CODES[@]}"
+      echo "[ERR] You need to manually edit ${tmp_list} to have only sample codes 'T' or 'N' "
+      echo "[ERR] Exiting now..."
+      exit 1
+    fi
+
+    echo "[INFO] checking for control samples in temporary VCF list and removing them"
+    if grep -q "${controlPrefix}" "${tmp_list}"; then
+        echo "[WARN] The following sample(s) will not be entered into the VCF file because they are suspected test/controls..."
+        grep "${controlPrefix}" ${tmp_list}
+        sed -i "/${controlPrefix}/d" ${tmp_list}
+    fi
+
+    cat ${tmp_list} | sort | uniq > ${tmp_list}.uniq
+    mv ${tmp_list}.uniq TSO500_vcf_list.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: \$(awk -W version 2>&1 | grep awk | sed 's/mawk //')
+    END_VERSIONS
+    """
+
+    stub:
+    def tmp_list = "TSO500_vcf_list.tsv.tmp"
+    """
+    touch ${tmp_list}
+    mv ${tmp_list} TSO500_vcf_list.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: stub
+    END_VERSIONS
+    """
+}

--- a/modules/local/update_small_variant_vcf_list/update_small_variant_vcf_list.nf
+++ b/modules/local/update_small_variant_vcf_list/update_small_variant_vcf_list.nf
@@ -28,60 +28,60 @@ process UPDATE_SMALL_VARIANT_VCF_LIST {
     BAD_SAMPLE_TYPE_CODES=()
     for SAMPLE_VCF in `ls -1 ${results}/*/*/*_MergedSmallVariants.genome.vcf`
     do
-      SAMPLE_ID=`echo \${SAMPLE_VCF} | sed "s/\\(.*\\/\\)\\(.*\\)\\(_MergedSmallVariants.genome.vcf\\)/\\\\2/"`
-      SAMPLE_TYPE_CODE=`echo \${SAMPLE_ID} | awk '{print substr(\$1, 13, 1)}'`
+        SAMPLE_ID=`echo \${SAMPLE_VCF} | sed "s/\\(.*\\/\\)\\(.*\\)\\(_MergedSmallVariants.genome.vcf\\)/\\\\2/"`
+        SAMPLE_TYPE_CODE=`echo \${SAMPLE_ID} | awk '{print substr(\$1, 13, 1)}'`
 
-      # check that sample type code is not an empty string
-      if [[  -z "\${SAMPLE_TYPE_CODE// }" ]]
-      then
-          echo "[ERR] \\\$SAMPLE_TYPE_CODE cannot be empty! Check that sample IDs follow inpred nomenclature"
-          echo "[ERR] Exiting now..."
-          exit 1
-      fi
+        # check that sample type code is not an empty string
+        if [[  -z "\${SAMPLE_TYPE_CODE// }" ]]
+        then
+            echo "[ERR] \\\$SAMPLE_TYPE_CODE cannot be empty! Check that sample IDs follow inpred nomenclature"
+            echo "[ERR] Exiting now..."
+            exit 1
+        fi
 
-      PATIENT_ID=\${SAMPLE_ID%%-*}
-      PATIENT_SAMPLE_COUNT=`grep "\${PATIENT_ID}" ${tmp_list} | wc -l`
+        PATIENT_ID=\${SAMPLE_ID%%-*}
+        PATIENT_SAMPLE_COUNT=`grep "\${PATIENT_ID}" ${tmp_list} | wc -l`
 
-      SAMPLE_TYPE_CODE_OK_STRING="[OK]"
-      if [ \${SAMPLE_TYPE_CODE} != "T" ] && [ \${SAMPLE_TYPE_CODE} != "N" ]
-      then
-        SAMPLE_TYPE_CODE_OK_STRING="[not \"T\" or \"N\"!]"
-        echo "[WARN] Unknown sample type code '\$SAMPLE_TYPE_CODE' encountered!"
-        echo "[WARN] Only sample type codes 'T' and 'N' are allowed in the VCF list file!"
-        case \${SAMPLE_TYPE_CODE} in
-            ["P","p","R","r","D","d","C","L","M","X"])
-            echo "[INFO] Replacing sample type code '\$SAMPLE_TYPE_CODE' with value 'T' "
-            sed -i 's/[P,p,R,r,D,d,C,L,M,X]\$/T/' ${tmp_list}
-            SAMPLE_TYPE_CODE="T"
-            SAMPLE_TYPE_CODE_OK_STRING="[OK]"
-            ;;
-        *)
-            echo "[WARN] You need to manually edit ${tmp_list} by replacing the unknown sample type code '\$SAMPLE_TYPE_CODE' with either 'T' or 'N' "
-            BAD_SAMPLE_TYPE_CODES+=(\${SAMPLE_TYPE_CODE})
-            ;;
-        esac
-      fi
+        SAMPLE_TYPE_CODE_OK_STRING="[OK]"
+        if [ \${SAMPLE_TYPE_CODE} != "T" ] && [ \${SAMPLE_TYPE_CODE} != "N" ]
+        then
+            SAMPLE_TYPE_CODE_OK_STRING="[not \"T\" or \"N\"!]"
+            echo "[WARN] Unknown sample type code '\$SAMPLE_TYPE_CODE' encountered!"
+            echo "[WARN] Only sample type codes 'T' and 'N' are allowed in the VCF list file!"
+            case \${SAMPLE_TYPE_CODE} in
+                ["P","p","R","r","D","d","C","L","M","X"])
+                echo "[INFO] Replacing sample type code '\$SAMPLE_TYPE_CODE' with value 'T' "
+                sed -i 's/[P,p,R,r,D,d,C,L,M,X]\$/T/' ${tmp_list}
+                SAMPLE_TYPE_CODE="T"
+                SAMPLE_TYPE_CODE_OK_STRING="[OK]"
+                ;;
+            *)
+                echo "[WARN] You need to manually edit ${tmp_list} by replacing the unknown sample type code '\$SAMPLE_TYPE_CODE' with either 'T' or 'N' "
+                BAD_SAMPLE_TYPE_CODES+=(\${SAMPLE_TYPE_CODE})
+                ;;
+            esac
+        fi
 
-      PATIENT_SAMPLE_COUNT_OK_STRING="[OK]"
-      if [ \${PATIENT_SAMPLE_COUNT} -ne 1 ]
-      then
-        PATIENT_SAMPLE_COUNT_OK_STRING="[not 1!]"
-      fi
+        PATIENT_SAMPLE_COUNT_OK_STRING="[OK]"
+        if [ \${PATIENT_SAMPLE_COUNT} -ne 1 ]
+        then
+            PATIENT_SAMPLE_COUNT_OK_STRING="[not 1!]"
+        fi
 
-      echo "[INFO] sample VCF: \${SAMPLE_VCF}"
-      echo "[INFO] sample ID: \${SAMPLE_ID}"
-      echo "[INFO] sample type code: \${SAMPLE_TYPE_CODE} \${SAMPLE_TYPE_CODE_OK_STRING}"
-      echo "[INFO] patient ID: \${PATIENT_ID}"
-      echo "[INFO] patient sample count: \${PATIENT_SAMPLE_COUNT} \${PATIENT_SAMPLE_COUNT_OK_STRING}"
+        echo "[INFO] sample VCF: \${SAMPLE_VCF}"
+        echo "[INFO] sample ID: \${SAMPLE_ID}"
+        echo "[INFO] sample type code: \${SAMPLE_TYPE_CODE} \${SAMPLE_TYPE_CODE_OK_STRING}"
+        echo "[INFO] patient ID: \${PATIENT_ID}"
+        echo "[INFO] patient sample count: \${PATIENT_SAMPLE_COUNT} \${PATIENT_SAMPLE_COUNT_OK_STRING}"
     done
 
     if [ \${#BAD_SAMPLE_TYPE_CODES[@]} -gt 0 ]
     then
-      echo "[ERR] The following unknown SAMPLE_TYPE_CODE(s) exist in ${tmp_list}:"
-      echo "\${BAD_SAMPLE_TYPE_CODES[@]}"
-      echo "[ERR] You need to manually edit ${tmp_list} to have only sample codes 'T' or 'N' "
-      echo "[ERR] Exiting now..."
-      exit 1
+        echo "[ERR] The following unknown SAMPLE_TYPE_CODE(s) exist in ${tmp_list}:"
+        echo "\${BAD_SAMPLE_TYPE_CODES[@]}"
+        echo "[ERR] You need to manually edit ${tmp_list} to have only sample codes 'T' or 'N' "
+        echo "[ERR] Exiting now..."
+        exit 1
     fi
 
     echo "[INFO] checking for control samples in temporary VCF list and removing them"

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ params {
     // Input options
     input                      = null
     tso500_resource_folder     = null
+    small_variant_vcf_list     = null
 
     // Boilerplate options
     outdir                       = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir", "tso500_resource_folder"],
+            "required": ["input", "outdir", "tso500_resource_folder", "small_variant_vcf_list"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -36,6 +36,16 @@
                     "description": "Path to directory where all reference files, required by the TSO500 LocalApp, are stored.",
                     "help_text": "The resource directory is usually obtained together with the LocalApp image.",
                     "fa_icon": "fas fa-folder-open"
+                },
+                "small_variant_vcf_list": {
+                    "type": "string",
+                    "format": "file-path",
+                    "exists": true,
+                    "mimetype": "text/tsv",
+                    "pattern": "^\\S+\\.tsv$",
+                    "description": "Path to tab-separated file containing list of vcf files used to update the small variant recurrence table.",
+                    "help_text": "Can be an empty file if no previous VCF files are available.",
+                    "fa_icon": "fas fa-file-tsv"
                 }
             }
         },

--- a/workflows/main.nf
+++ b/workflows/main.nf
@@ -8,6 +8,7 @@ include { GATHER                             } from '../modules/local/local_app/
 include { LOCAL_APP as LOCAL_APP_DEMULTIPLEX } from '../modules/local/local_app/local_app'
 include { LOCAL_APP as LOCAL_APP_TSO500      } from '../modules/local/local_app/local_app'
 include { LOCAL_APP_PREPPER                  } from '../modules/local/local_app_prepper/local_app_prepper'
+include { UPDATE_SMALL_VARIANT_VCF_LIST      } from '../modules/local/update_small_variant_vcf_list/update_small_variant_vcf_list'
 include { paramsSummaryMap                   } from 'plugin/nf-schema'
 include { samplesheetToList                  } from 'plugin/nf-schema'
 include { softwareVersionsToYAML             } from '../subworkflows/nf-core/utils_nfcore_pipeline'
@@ -86,6 +87,13 @@ workflow MAIN {
         file(params.tso500_resource_folder)
     )
     versions = versions.mix(GATHER.out.versions.first())
+
+    // MODULE: Update small variant vcf list
+    UPDATE_SMALL_VARIANT_VCF_LIST (
+        GATHER.out.results,
+        file(params.small_variant_vcf_list)
+    )
+    versions = versions.mix(UPDATE_SMALL_VARIANT_VCF_LIST.out.versions.first())
 
     // collate and save software versions
     softwareVersionsToYAML(versions)


### PR DESCRIPTION
Hey guys,

here is my first draft for the module that should update the small variant vcf list. Our code at HUS might be different from your nodes so we need to discuss if the changes we made would work forall other nodes (I included at least one representative from each node now). I have some very old code from OUS which does not check for control samples and does not remap certain tumor types so please let me know if that is something we don't want a.k.a. only HUS wants.

I guess you might have concerns about where the files are put. For now, let's not focus too much on that. We can change these paths later and create specific profiles for each node.

I also thought that this bash script is a bit clumsy and maybe we want something in python instead doing all of this. I would volunteer to put something together in case we agree to go that route. Also, for me it would make sense to not update but rather recreate the file each time we run this process and just glob all runs' small variant vcf files, remove control samples and remap sample types (if we agree on that), exclude vcfs/samples/patients we don't want (have a blacklist of those somewhere), and finally sort and uniq the list.

Please reach out in case you have questions either on Teams or here. We can also do a meeting if that is easier for you.

Your feedback is highly appreciated 🙂 